### PR TITLE
Modify DefaultSolver.processInstanceLoad() for consistency

### DIFF
--- a/src/main/java/pascal/taie/analysis/pta/core/solver/DefaultSolver.java
+++ b/src/main/java/pascal/taie/analysis/pta/core/solver/DefaultSolver.java
@@ -354,12 +354,11 @@ public class DefaultSolver implements Solver {
         Var var = baseVar.getVar();
         for (LoadField load : var.getLoadFields()) {
             Var toVar = load.getLValue();
-            JField field = load.getFieldRef().resolve();
             if (isConcerned(toVar)) {
                 CSVar to = csManager.getCSVar(context, toVar);
                 pts.forEach(baseObj -> {
                     InstanceField instField = csManager.getInstanceField(
-                            baseObj, field);
+                            baseObj, load.getFieldRef().resolve());
                     addPFGEdge(instField, to, PointerFlowEdge.Kind.INSTANCE_LOAD);
                 });
             }


### PR DESCRIPTION
In this patch, I modified DefaultSolver.processInstanceLoad()
- for consistent with `processInstanceStore`
- if `isConcerned(toVar)` is false, we do not need this `load.getFieldRef().resolve()` call