### PR TITLE
Cha fix

### DIFF
--- a/src/main/java/pascal/taie/analysis/graph/callgraph/CHABuilder.java
+++ b/src/main/java/pascal/taie/analysis/graph/callgraph/CHABuilder.java
@@ -164,7 +164,11 @@ class CHABuilder implements CGBuilder<Invoke, JMethod> {
                 }
                 yield callees.size() <= calleeLimit ? callees : Set.of();
             }
-            case SPECIAL, STATIC -> Set.of(callSite.getMethodRef().resolve());
+            case SPECIAL, STATIC -> {
+                JMethod callee = CallGraphs.resolveCallee(null, callSite);
+                if (callee!= null) yield Set.of(callee);
+                else yield Set.of();
+            }
             case DYNAMIC -> {
                 logger.debug("CHA cannot resolve invokedynamic {}", callSite);
                 yield Set.of();


### PR DESCRIPTION
change: 
in file CHABuilder.Java
callSite.getMethodRef().resolve() may casue exceptions, use  CallGraphs.resolveCallee(null, callSite) instead. 

test case:
XCorpus -- aoi-2.8.1

error log before repair:
Exception in thread "main" pascal.taie.ir.proginfo.MethodResolutionFailedException: Cannot resolve <com.sun.opengl.util.BufferUtil: java.nio.FloatBuffer newFloatBuffer(int)>
	at pascal.taie.ir.proginfo.MethodRef.resolve(MethodRef.java:184)
	at pascal.taie.analysis.graph.callgraph.CHABuilder.resolveCalleesOf(CHABuilder.java:167)
	at pascal.taie.analysis.graph.callgraph.CHABuilder.lambda$buildCallGraph$1(CHABuilder.java:129)
	at java.base/java.util.ArrayList$Itr.forEachRemaining(ArrayList.java:1003)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
	at pascal.taie.analysis.graph.callgraph.CHABuilder.buildCallGraph(CHABuilder.java:128)
	at pascal.taie.analysis.graph.callgraph.CHABuilder.build(CHABuilder.java:102)
	at pascal.taie.analysis.graph.callgraph.CallGraphBuilder.analyze(CallGraphBuilder.java:67)
	at pascal.taie.analysis.graph.callgraph.CallGraphBuilder.analyze(CallGraphBuilder.java:37)
	at pascal.taie.analysis.AnalysisManager.runProgramAnalysis(AnalysisManager.java:148)
	at pascal.taie.analysis.AnalysisManager.runAnalysis(AnalysisManager.java:135)
	at pascal.taie.analysis.AnalysisManager.lambda$execute$0(AnalysisManager.java:104)
	at pascal.taie.util.Timer.runAndCount(Timer.java:93)
	at pascal.taie.analysis.AnalysisManager.lambda$execute$1(AnalysisManager.java:103)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at pascal.taie.analysis.AnalysisManager.execute(AnalysisManager.java:102)
	at pascal.taie.Main.executePlan(Main.java:154)
	at pascal.taie.Main.lambda$main$0(Main.java:62)
	at pascal.taie.util.Timer.lambda$runAndCount$0(Timer.java:112)
	at pascal.taie.util.Timer.runAndCount(Timer.java:93)
	at pascal.taie.util.Timer.runAndCount(Timer.java:111)
	at pascal.taie.util.Timer.runAndCount(Timer.java:107)
	at pascal.taie.Main.main(Main.java:52)

log after repair:
cg starts ...
Building call graph by CHA
Ignore methods of java.lang.Object
Call graph has 28841 reachable methods and 334714 edges
Dumping call graph to /home/byx/testSpace/javaprjs/aoi-2.8.1/cha-output/call-graph.dot
Dumping reachable methods to /home/byx/testSpace/javaprjs/aoi-2.8.1/cha-output/reachable-methods.txt
Dumping call edges to /home/byx/testSpace/javaprjs/aoi-2.8.1/cha-output/call-edges.txt
cg finishes, elapsed time: 15.79s
Tai-e finishes, elapsed time: 24.82s

options:
optionsFile: null
printHelp: false
classPath:
- ../../testSpace/javaprjs/.lib/maven-artifact-2.0.jar
- ../../testSpace/javaprjs/.lib/ant-launcher-1.6.5.jar
- ../../testSpace/javaprjs/.lib/org.apache.servicemix.bundles.jetty-6.1.25_1.jar
- ../../testSpace/javaprjs/.lib/bananas.jar
- ../../testSpace/javaprjs/.lib/substance.jar
- ../../testSpace/javaprjs/.lib/mail-1.3.1.jar
- ../../testSpace/javaprjs/.lib/stamptool.jar
- ../../testSpace/javaprjs/.lib/BCEL.jar
- ../../testSpace/javaprjs/.lib/jsr305.jar
- ../../testSpace/javaprjs/.lib/Buoy.jar
- ../../testSpace/javaprjs/.lib/tinylaf.jar
- ../../testSpace/javaprjs/.lib/jfreechart-common-1.0.0.jar
- ../../testSpace/javaprjs/.lib/mx4j-remote.jar
- ../../testSpace/javaprjs/.lib/kawa-1.9.1.jar
- ../../testSpace/javaprjs/.lib/xbean.jar
- ../../testSpace/javaprjs/.lib/log4j-1.2.15.jar
- ../../testSpace/javaprjs/.lib/fife.common.jar
- ../../testSpace/javaprjs/.lib/hibernate-3.2.3.ga.jar
- ../../testSpace/javaprjs/.lib/commons-digester-1.5.jar
- ../../testSpace/javaprjs/.lib/oro.jar
- ../../testSpace/javaprjs/.lib/jogg-0.0.7.jar
- ../../testSpace/javaprjs/.lib/com.springsource.com.lowagie.text-2.0.8.jar
- ../../testSpace/javaprjs/.lib/mysql-connector-java-3.0.17-ga-bin.jar
- ../../testSpace/javaprjs/.lib/iri-0.8-sources.jar
- ../../testSpace/javaprjs/.lib/dsi.unimi.it-1.2.0.jar
- ../../testSpace/javaprjs/.lib/jms-1.1.jar
- ../../testSpace/javaprjs/.lib/cmgatejava120.jar
- ../../testSpace/javaprjs/.lib/bcmail.jar
- ../../testSpace/javaprjs/.lib/cojen-2.0.jar
- ../../testSpace/javaprjs/.lib/ant.jar
- ../../testSpace/javaprjs/.lib/spring-mock-1.2.6.jar
- ../../testSpace/javaprjs/.lib/jdai.jar
- ../../testSpace/javaprjs/.lib/helpgui-1.1b.jar
- ../../testSpace/javaprjs/.lib/dwr.jar
- ../../testSpace/javaprjs/.lib/lucene.jar
- ../../testSpace/javaprjs/.lib/gwt-servlet.jar
- ../../testSpace/javaprjs/.lib/selenium-java-2.0b1.jar
- ../../testSpace/javaprjs/.lib/hibernate.jar
- ../../testSpace/javaprjs/.lib/ant-contrib.jar
- ../../testSpace/javaprjs/.lib/errors-taglib-1.1.jar
- ../../testSpace/javaprjs/.lib/ecj-3.6.jar
- ../../testSpace/javaprjs/.lib/javaswf-CVS-SNAPSHOT-1.jar
- ../../testSpace/javaprjs/.lib/poi-scratchpad-2.0-RC1-20031102.jar
- ../../testSpace/javaprjs/.lib/xml-apis-2.0.2.jar
- ../../testSpace/javaprjs/.lib/itext-1.2.0.jar
- ../../testSpace/javaprjs/.lib/hme.jar
- ../../testSpace/javaprjs/.lib/svnant.jar
- ../../testSpace/javaprjs/.lib/dps-sdk-2.0.0.jar
- ../../testSpace/javaprjs/.lib/RText.jar
- ../../testSpace/javaprjs/.lib/Octopus.jar
- ../../testSpace/javaprjs/.lib/findbugsGUI.jar
- ../../testSpace/javaprjs/.lib/JFlex.jar
- ../../testSpace/javaprjs/.lib/csg-bytecode.jar
- ../../testSpace/javaprjs/.lib/javax.servlet-3.0.jar
- ../../testSpace/javaprjs/.lib/jfreechart.jar
- ../../testSpace/javaprjs/.lib/com.springsource.org.apache.maven.ant-2.0.8.jar
- ../../testSpace/javaprjs/.lib/stylebook-1.0-b3_xalan-2.jar
- ../../testSpace/javaprjs/.lib/nanoxml.jar
- ../../testSpace/javaprjs/.lib/poi-3.5-FINAL.jar
- ../../testSpace/javaprjs/.lib/j2ee.jar
- ../../testSpace/javaprjs/.lib/org.apache.commons.logging-1.1.1.jar
- ../../testSpace/javaprjs/.lib/dynamo-enhancer.jar
- ../../testSpace/javaprjs/.lib/java_cup.jar
- ../../testSpace/javaprjs/.lib/ant_doxygen.jar
- ../../testSpace/javaprjs/.lib/xfire-jsr181-api-1.0-M1.jar
- ../../testSpace/javaprjs/.lib/commons-pool-1.2.jar
- ../../testSpace/javaprjs/.lib/rs-0.1.jar
- ../../testSpace/javaprjs/.lib/miglayout-4.0-swing.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-thirdparty-imageinfo-0.1.1.jar
- ../../testSpace/javaprjs/.lib/geronimo-javamail_1.3.1_spec-1.0.jar
- ../../testSpace/javaprjs/.lib/jzonic.jar
- ../../testSpace/javaprjs/.lib/finalist-ant-1.3.jar
- ../../testSpace/javaprjs/.lib/fop.jar
- ../../testSpace/javaprjs/.lib/xalan.jar
- ../../testSpace/javaprjs/.lib/jfreechart-1.0.6.jar
- ../../testSpace/javaprjs/.lib/jclasslib.jar
- ../../testSpace/javaprjs/.lib/widgets.jar
- ../../testSpace/javaprjs/.lib/iri-0.8.jar
- ../../testSpace/javaprjs/.lib/spring-web-2.5.6.jar
- ../../testSpace/javaprjs/.lib/dom4j-1.6.1.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-mask-1.0-alpha1.jar
- ../../testSpace/javaprjs/.lib/hibernate-entitymanager.jar
- ../../testSpace/javaprjs/.lib/poi-2.0-RC1-20031102.jar
- ../../testSpace/javaprjs/.lib/svnClientAdapter.jar
- ../../testSpace/javaprjs/.lib/jFormatString.jar
- ../../testSpace/javaprjs/.lib/TinyXML.jar
- ../../testSpace/javaprjs/.lib/jgraph.jar
- ../../testSpace/javaprjs/.lib/javamail-crypto-bouncycastle-smime.jar
- ../../testSpace/javaprjs/.lib/jnlp.jar
- ../../testSpace/javaprjs/.lib/rentEz.jar
- ../../testSpace/javaprjs/.lib/classes.jar
- ../../testSpace/javaprjs/.lib/pdf-transcoder.jar
- ../../testSpace/javaprjs/.lib/findbugs.jar
- ../../testSpace/javaprjs/.lib/org.apache.commons.beanutils.jar
- ../../testSpace/javaprjs/.lib/displaytag-1.1.jar
- ../../testSpace/javaprjs/.lib/commons-dbcp.jar
- ../../testSpace/javaprjs/.lib/concurrent.jar
- ../../testSpace/javaprjs/.lib/jakarta-commons-lang-2.1.jar
- ../../testSpace/javaprjs/.lib/sunlabs_mock.jar
- ../../testSpace/javaprjs/.lib/plexus-utils-1.5.5.jar
- ../../testSpace/javaprjs/.lib/jta.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-webtheme-jar-1.0-alpha1.jar
- ../../testSpace/javaprjs/.lib/wstx-lgpl-4.0pr1.jar
- ../../testSpace/javaprjs/.lib/doccheck.jar
- ../../testSpace/javaprjs/.lib/eclipse.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-build-0.6.2.jar
- ../../testSpace/javaprjs/.lib/j3dcore.jar
- ../../testSpace/javaprjs/.lib/javax.servlet.jar
- ../../testSpace/javaprjs/.lib/xercesImpl.jar
- ../../testSpace/javaprjs/.lib/javazoom.jar
- ../../testSpace/javaprjs/.lib/derbynet.jar
- ../../testSpace/javaprjs/.lib/com.springsource.org.hibernate-3.3.2.GA.jar
- ../../testSpace/javaprjs/.lib/org.eclipse.swt.win32.win32.x86_3.7.1.v3738a.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-util-1.0-alpha1.jar
- ../../testSpace/javaprjs/.lib/informa.jar
- ../../testSpace/javaprjs/.lib/mm.mysql-2.0.14.jar
- ../../testSpace/javaprjs/.lib/finalist-taglib-1.0.jar
- ../../testSpace/javaprjs/.lib/pja.jar
- ../../testSpace/javaprjs/.lib/swingsetthemes.jar
- ../../testSpace/javaprjs/.lib/jbossws-spi-4.2.2.jar
- ../../testSpace/javaprjs/.lib/AppleJavaExtensions.jar
- ../../testSpace/javaprjs/.lib/jdt-compiler-3.1.1.jar
- ../../testSpace/javaprjs/.lib/com.springsource.org.codehaus.groovy-1.6.5.jar
- ../../testSpace/javaprjs/.lib/cos.jar
- ../../testSpace/javaprjs/.lib/acegi-security-1.0.1.jar
- ../../testSpace/javaprjs/.lib/ejb3-persistence.jar
- ../../testSpace/javaprjs/.lib/webwork-2.1.6.jar
- ../../testSpace/javaprjs/.lib/jbet3-R1.jar
- ../../testSpace/javaprjs/.lib/GroboUtils-5-core.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-util-0.6.2.jar
- ../../testSpace/javaprjs/.lib/jakarta-tablibs-standard-1.1.2.jar
- ../../testSpace/javaprjs/.lib/imap.jar
- ../../testSpace/javaprjs/.lib/jacob-1.14.3.jar
- ../../testSpace/javaprjs/.lib/hibernate-3.1.2.jar
- ../../testSpace/javaprjs/.lib/commons-dbcp-1.2.1.jar
- ../../testSpace/javaprjs/.lib/jshortcut.jar
- ../../testSpace/javaprjs/.lib/spring-context.jar
- ../../testSpace/javaprjs/.lib/quaqua.jar
- ../../testSpace/javaprjs/.lib/groovy-1.0-jsr-01-ivata.jar
- ../../testSpace/javaprjs/.lib/ilf-gpl.jar
- ../../testSpace/javaprjs/.lib/openide-lookup.jar
- ../../testSpace/javaprjs/.lib/hibernate-annotations.jar
- ../../testSpace/javaprjs/.lib/gnujaxp.jar
- ../../testSpace/javaprjs/.lib/dawn-1.1.1.jar
- ../../testSpace/javaprjs/.lib/nanocontainer-1.0-RC-3.jar
- ../../testSpace/javaprjs/.lib/spring-support.jar
- ../../testSpace/javaprjs/.lib/jiapi.jar
- ../../testSpace/javaprjs/.lib/spring-dao.jar
- ../../testSpace/javaprjs/.lib/spice-jndikit-1.2.jar
- ../../testSpace/javaprjs/.lib/WinService.jar
- ../../testSpace/javaprjs/.lib/freemarker.jar
- ../../testSpace/javaprjs/.lib/jasperreports-1.2.0.jar
- ../../testSpace/javaprjs/.lib/quartz-1.5.2.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-web-0.6.2.jar
- ../../testSpace/javaprjs/.lib/myvietnam.jar
- ../../testSpace/javaprjs/.lib/jampal.jar
- ../../testSpace/javaprjs/.lib/napkinlaf.jar
- ../../testSpace/javaprjs/.lib/SMiley.jar
- ../../testSpace/javaprjs/.lib/openide-loaders.jar
- ../../testSpace/javaprjs/.lib/commons-email-1.0.jar
- ../../testSpace/javaprjs/.lib/generic-exceptions-struts-1.2.jar
- ../../testSpace/javaprjs/.lib/javassist-2.6.ga.jar
- ../../testSpace/javaprjs/.lib/bcprov-1.45.jar
- ../../testSpace/javaprjs/.lib/jakarta-oro-2.0.6.jar
- ../../testSpace/javaprjs/.lib/yahoo_search.jar
- ../../testSpace/javaprjs/.lib/mbox.jar
- ../../testSpace/javaprjs/.lib/xdoclet-apache-module-1.2.2.jar
- ../../testSpace/javaprjs/.lib/dnsjava-1.6.2.jar
- ../../testSpace/javaprjs/.lib/cglib.jar
- ../../testSpace/javaprjs/.lib/commons-daemon.jar
- ../../testSpace/javaprjs/.lib/derby.jar
- ../../testSpace/javaprjs/.lib/resolver.jar
- ../../testSpace/javaprjs/.lib/syntax.jar
- ../../testSpace/javaprjs/.lib/swtgraphics2d.jar
- ../../testSpace/javaprjs/.lib/activation-1.0.2.jar
- ../../testSpace/javaprjs/.lib/xdoclet-spring-module-1.2.2.jar
- ../../testSpace/javaprjs/.lib/htmlparser.jar
- ../../testSpace/javaprjs/.lib/mail.jar
- ../../testSpace/javaprjs/.lib/spring-hibernate.jar
- ../../testSpace/javaprjs/.lib/org.osgi.foundation-1.2.0.jar
- ../../testSpace/javaprjs/.lib/jxl.jar
- ../../testSpace/javaprjs/.lib/org-netbeans-modules-editor-fold.jar
- ../../testSpace/javaprjs/.lib/jta1.0.1.jar
- ../../testSpace/javaprjs/.lib/policy-4.2.2.GA.jar
- ../../testSpace/javaprjs/.lib/activation.jar
- ../../testSpace/javaprjs/.lib/standard-1.0.6.jar
- ../../testSpace/javaprjs/.lib/xjavadoc-1.5-snapshot050611.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-masks-0.1.jar
- ../../testSpace/javaprjs/.lib/javax.jms_1.1.0.jar
- ../../testSpace/javaprjs/.lib/ejb3-persistence-3.1beta8.jar
- ../../testSpace/javaprjs/.lib/com.springsource.org.mortbay.jetty.server-6.1.9.jar
- ../../testSpace/javaprjs/.lib/jta-1.0.1.jar
- ../../testSpace/javaprjs/.lib/java-cup.jar
- ../../testSpace/javaprjs/.lib/sequencegenerator-ejb-1.0.jar
- ../../testSpace/javaprjs/.lib/sandler.jar
- ../../testSpace/javaprjs/.lib/hme-host-sample.jar
- ../../testSpace/javaprjs/.lib/runtime.jar
- ../../testSpace/javaprjs/.lib/avro-tools-1.3.3.jar
- ../../testSpace/javaprjs/.lib/org.springframework.web.servlet-3.1.0.M2.jar
- ../../testSpace/javaprjs/.lib/acegi-security-1.0.0-RC2.jar
- ../../testSpace/javaprjs/.lib/nanocontainer-1.0-RC-2.jar
- ../../testSpace/javaprjs/.lib/xerces_2_5_0.jar
- ../../testSpace/javaprjs/.lib/xml-apis-ext.jar
- ../../testSpace/javaprjs/.lib/org-netbeans-modules-editor-util.jar
- ../../testSpace/javaprjs/.lib/mp3dings.jar
- ../../testSpace/javaprjs/.lib/wayback-core-1.2.0.jar
- ../../testSpace/javaprjs/.lib/servlet-api-5.5.15.jar
- ../../testSpace/javaprjs/.lib/jboss-xml-binding-1.0.0.SP1.jar
- ../../testSpace/javaprjs/.lib/xalan2jdoc.jar
- ../../testSpace/javaprjs/.lib/servlet-2.3.jar
- ../../testSpace/javaprjs/.lib/nekohtml.jar
- ../../testSpace/javaprjs/.lib/dnsjava-2.0.5.jar
- ../../testSpace/javaprjs/.lib/simpleuml-1.0.1.jar
- ../../testSpace/javaprjs/.lib/clientsession-0.2.jar
- ../../testSpace/javaprjs/.lib/mx4j.jar
- ../../testSpace/javaprjs/.lib/je-3.2.74.jar
- ../../testSpace/javaprjs/.lib/hibernate-2.1.7c.jar
- ../../testSpace/javaprjs/.lib/OctopusGenerator.jar
- ../../testSpace/javaprjs/.lib/derbytools.jar
- ../../testSpace/javaprjs/.lib/PngEncoder.jar
- ../../testSpace/javaprjs/.lib/versioncheck.jar
- ../../testSpace/javaprjs/.lib/jakarta-regexp-1.3.jar
- ../../testSpace/javaprjs/.lib/coreplugin.jar
- ../../testSpace/javaprjs/.lib/Buoyx.jar
- ../../testSpace/javaprjs/.lib/toniclf.jar
- ../../testSpace/javaprjs/.lib/httpclient-4.0.1-tests.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-webtheme-jar-0.6.2.jar
- ../../testSpace/javaprjs/.lib/jcom-2.2.4.jar
- ../../testSpace/javaprjs/.lib/castor-1.1.2.1-jdo.jar
- ../../testSpace/javaprjs/.lib/jargs.jar
- ../../testSpace/javaprjs/.lib/l2fprod-common-all.jar
- ../../testSpace/javaprjs/.lib/jax.jar
- ../../testSpace/javaprjs/.lib/hibernate-3.0.5.jar
- ../../testSpace/javaprjs/.lib/jndi-1.2.1.jar
- ../../testSpace/javaprjs/.lib/hibernate-annotations-3.0beta1.jar
- ../../testSpace/javaprjs/.lib/mx4j-tools.jar
- ../../testSpace/javaprjs/.lib/spring-remoting.jar
- ../../testSpace/javaprjs/.lib/hibernate-commons-annotations.jar
- ../../testSpace/javaprjs/.lib/pop3.jar
- ../../testSpace/javaprjs/.lib/spring-context-2.5.6.jar
- ../../testSpace/javaprjs/.lib/xml-apis.jar
- ../../testSpace/javaprjs/.lib/tacos4-beta-1-lib.jar
- ../../testSpace/javaprjs/.lib/javax.jms.jar
- ../../testSpace/javaprjs/.lib/andromda.jar
- ../../testSpace/javaprjs/.lib/xom-1.2.jar
- ../../testSpace/javaprjs/.lib/JLex.jar
- ../../testSpace/javaprjs/.lib/rsyntaxtextarea.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-mask-0.6.2.jar
- ../../testSpace/javaprjs/.lib/dynamo-rt.jar
- ../../testSpace/javaprjs/.lib/dnsjava-2.0.3.jar
- ../../testSpace/javaprjs/.lib/jawin.jar
- ../../testSpace/javaprjs/.lib/commons-collections.jar
- ../../testSpace/javaprjs/.lib/picocontainer-1.2-RC-1.jar
- ../../testSpace/javaprjs/.lib/javaOTP.jar
- ../../testSpace/javaprjs/.lib/fw.jar
- ../../testSpace/javaprjs/.lib/MHS.jar
- ../../testSpace/javaprjs/.lib/xfire-all-1.0.jar
- ../../testSpace/javaprjs/.lib/jmi.jar
- ../../testSpace/javaprjs/.lib/kunststoff.jar
- ../../testSpace/javaprjs/.lib/ant-jmeter-2.0.3.jar
- ../../testSpace/javaprjs/.lib/jrcs-diff.jar
- ../../testSpace/javaprjs/.lib/jakarta-taglibs-jstl-1.1.2.jar
- ../../testSpace/javaprjs/.lib/TabPanel.jar
- ../../testSpace/javaprjs/.lib/svnjavahl.jar
- ../../testSpace/javaprjs/.lib/smalltext-0.1.4.jar
- ../../testSpace/javaprjs/.lib/bcpg.jar
- ../../testSpace/javaprjs/.lib/hsqldb.jar
- ../../testSpace/javaprjs/.lib/jasper-5.5.17.v201101211617.jar
- ../../testSpace/javaprjs/.lib/bsf.jar
- ../../testSpace/javaprjs/.lib/yuicompressor.jar
- ../../testSpace/javaprjs/.lib/com.springsource.org.apache.tools.ant-1.8.1.jar
- ../../testSpace/javaprjs/.lib/svnkit.jar
- ../../testSpace/javaprjs/.lib/kunststoff-2.0.1.jar
- ../../testSpace/javaprjs/.lib/hibernate-annotations-3.1beta8.jar
- ../../testSpace/javaprjs/.lib/spring-orm.jar
- ../../testSpace/javaprjs/.lib/jboss-j2se.jar
- ../../testSpace/javaprjs/.lib/apache-logging-log4j.jar
- ../../testSpace/javaprjs/.lib/regexp.jar
- ../../testSpace/javaprjs/.lib/generic-exceptions-1.0.jar
- ../../testSpace/javaprjs/.lib/js.jar
- ../../testSpace/javaprjs/.lib/com.springsource.org.mortbay.util-6.1.9.jar
- ../../testSpace/javaprjs/.lib/TGGraphLayout.jar
- ../../testSpace/javaprjs/.lib/javax.ejb.jar
- ../../testSpace/javaprjs/.lib/Ostermiller.jar
- ../../testSpace/javaprjs/.lib/jboss-logging.jar
- ../../testSpace/javaprjs/.lib/jdbc-2.0.jar
- ../../testSpace/javaprjs/.lib/jsr173_1.0_api.jar
- ../../testSpace/javaprjs/.lib/servlet.jar
- ../../testSpace/javaprjs/.lib/javax_mail.jar
- ../../testSpace/javaprjs/.lib/wrapper.jar
- ../../testSpace/javaprjs/.lib/xalan2jtaglet.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-web-1.0-alpha1.jar
- ../../testSpace/javaprjs/.lib/jtidy-r872-jdk15.jar
- ../../testSpace/javaprjs/.lib/commons-logging.jar
- ../../testSpace/javaprjs/.lib/JimiProClasses.jar
- ../../testSpace/javaprjs/.lib/commonj-twm.jar
- ../../testSpace/javaprjs/.lib/mediamanager.jar
- ../../testSpace/javaprjs/.lib/jboss-saaj-4.2.2.jar
- ../../testSpace/javaprjs/.lib/nimrodlf.jar
- ../../testSpace/javaprjs/.lib/forms.jar
- ../../testSpace/javaprjs/.lib/bcel.jar
- ../../testSpace/javaprjs/.lib/sequencegenerator-ejb-1.0-sunone-client.jar
- ../../testSpace/javaprjs/.lib/javax.mail-1.3.3.01.jar
- ../../testSpace/javaprjs/.lib/xalan-2.6.0.jar
- ../../testSpace/javaprjs/.lib/aspirin.jar
- ../../testSpace/javaprjs/.lib/jboss.jar
- ../../testSpace/javaprjs/.lib/org-netbeans-modules-editor.jar
- ../../testSpace/javaprjs/.lib/dom4j-1.5-beta-2.jar
- ../../testSpace/javaprjs/.lib/hibernate-c3p0-3.3.1.GA.jar
- ../../testSpace/javaprjs/.lib/jbossws-client-jbossws-2.0.jar
- ../../testSpace/javaprjs/.lib/javax.persistence.jar
- ../../testSpace/javaprjs/.lib/dbunit.jar
- ../../testSpace/javaprjs/.lib/org.eclipse.swt_3.7.1.v3738a.jar
- ../../testSpace/javaprjs/.lib/ehcache-1.1.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-mask-0.6.jar
- ../../testSpace/javaprjs/.lib/sbbi-upnplib-1.0.2.jar
- ../../testSpace/javaprjs/.lib/json.jar
- ../../testSpace/javaprjs/.lib/jhelpaction.jar
- ../../testSpace/javaprjs/.lib/saaj.jar
- ../../testSpace/javaprjs/.lib/jbossws-common-jbossws-2.0.jar
- ../../testSpace/javaprjs/.lib/jdbc2_0-stdext.jar
- ../../testSpace/javaprjs/.lib/smack.jar
- ../../testSpace/javaprjs/.lib/apache-commons-lang.jar
- ../../testSpace/javaprjs/.lib/stringtemplate.jar
- ../../testSpace/javaprjs/.lib/org-netbeans-modules-editor-lib.jar
- ../../testSpace/javaprjs/.lib/ant-1.6.5.jar
- ../../testSpace/javaprjs/.lib/hibernate-tools-3.0.jar
- ../../testSpace/javaprjs/.lib/asm-attrs.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-mask-1.0.jar
- ../../testSpace/javaprjs/.lib/mailapi_1_3_1.jar
- ../../testSpace/javaprjs/.lib/jboss-system.jar
- ../../testSpace/javaprjs/.lib/statementexecutor-1.1.jar
- ../../testSpace/javaprjs/.lib/commons-httpclient-2.0-alpha2.jar
- ../../testSpace/javaprjs/.lib/excalibur-datasource-1.0.jar
- ../../testSpace/javaprjs/.lib/mg4j-2.0.1.jar
- ../../testSpace/javaprjs/.lib/smtp.jar
- ../../testSpace/javaprjs/.lib/jcommon.jar
- ../../testSpace/javaprjs/.lib/cortado-0.6.0.jar
- ../../testSpace/javaprjs/.lib/wsdl4j-1.2.jar
- ../../testSpace/javaprjs/.lib/spring.jar
- ../../testSpace/javaprjs/.lib/uninstaller.jar
- ../../testSpace/javaprjs/.lib/libidn-0.5.9.jar
- ../../testSpace/javaprjs/.lib/xsltc.jar
- ../../testSpace/javaprjs/.lib/js_build_tools.jar
- ../../testSpace/javaprjs/.lib/j3dutils.jar
- ../../testSpace/javaprjs/.lib/spring-web.jar
- ../../testSpace/javaprjs/.lib/xmlutil.jar
- ../../testSpace/javaprjs/.lib/lcrypto-jdk15.jar
- ../../testSpace/javaprjs/.lib/ibmjsse.jar
- ../../testSpace/javaprjs/.lib/ivatamasks-masks-0.1.1.jar
- ../../testSpace/javaprjs/.lib/antlr.jar
- ../../testSpace/javaprjs/.lib/browserlauncher.jar
- ../../testSpace/javaprjs/.lib/apache-xml-xalan.jar
- ../../testSpace/javaprjs/.lib/cornerstone.jar
- ../../testSpace/javaprjs/.lib/openide.jar
- ../../testSpace/javaprjs/.lib/csvjdbc.jar
- ../../testSpace/javaprjs/.lib/packageManager.jar
- ../../testSpace/javaprjs/.lib/bcprov.jar
- ../../testSpace/javaprjs/.lib/javamail-crypto-bouncycastle-openpgp.jar
- ../../testSpace/javaprjs/.lib/hibernate3.jar
- ../../testSpace/javaprjs/.lib/crimson-1.1.3.jar
- ../../testSpace/javaprjs/.lib/cobertura-1.9.jar
- ../../testSpace/javaprjs/.lib/log4j.jar
- ../../testSpace/javaprjs/.lib/asm.jar
- ../../testSpace/javaprjs/.lib/aheritrix-1.14.1.jar
- ../../testSpace/javaprjs/.lib/standard.jar
- ../../testSpace/javaprjs/.lib/javax.servlet.jsp.jar
- ../../testSpace/javaprjs/.lib/shiftone-arbor.jar
- ../../testSpace/javaprjs/.lib/java_30.jar
- ../../testSpace/javaprjs/.lib/autocomplete.jar
- ../../testSpace/javaprjs/.lib/mailapi.jar
- ../../testSpace/javaprjs/.lib/jython.jar
- ../../testSpace/javaprjs/.lib/acegi-security-tiger-1.0.0-RC2.jar
- ../../testSpace/javaprjs/.lib/remoteExperimentServer.jar
- ../../testSpace/javaprjs/.lib/spring-context-support.jar
- java-benchmarks/JREs/jre1.5/jce.jar
- java-benchmarks/JREs/jre1.5/jsse.jar
- java-benchmarks/JREs/jre1.5/rt.jar
appClassPath:
- ../../testSpace/javaprjs/aoi-2.8.1/bin
mainClass: artofillusion.ArtOfIllusion
inputClasses: []
javaVersion: 5
prependJVM: false
allowPhantom: true
worldBuilderClass: pascal.taie.frontend.soot.SootWorldBuilder
outputDir: ../../testSpace/javaprjs/aoi-2.8.1/cha-output
preBuildIR: false
worldCacheMode: false
scope: APP
nativeModel: true
planFile: null
analyses:
  cg: algorithm:cha;dump:true;dump-methods:true;dump-call-edges:true;
onlyGenPlan: false
keepResult:
- $KEEP-ALL

