### PR TITLE
Fix Mahjong's FieldPointsToGraph by handling non-functional MockObj in PTA Result

### DIFF
--- a/src/main/java/pascal/taie/analysis/pta/PointerAnalysisResultImpl.java
+++ b/src/main/java/pascal/taie/analysis/pta/PointerAnalysisResultImpl.java
@@ -210,6 +210,7 @@ public class PointerAnalysisResultImpl extends AbstractResultHolder
                 removeContexts(csManager.getCSVarsOf(base)
                         .stream()
                         .flatMap(Pointer::objects)
+                        .filter(obj -> obj.getObject().isFunctional())
                         .map(o -> csManager.getInstanceField(o, field))
                         .flatMap(InstanceField::objects)));
     }
@@ -226,6 +227,7 @@ public class PointerAnalysisResultImpl extends AbstractResultHolder
         // TODO - properly handle non-exist base.field
         return removeContexts(csManager.getCSObjsOf(base)
                 .stream()
+                .filter(obj -> obj.getObject().isFunctional())
                 .map(o -> csManager.getInstanceField(o, field))
                 .flatMap(InstanceField::objects));
     }
@@ -274,6 +276,7 @@ public class PointerAnalysisResultImpl extends AbstractResultHolder
                 removeContexts(csManager.getCSVarsOf(b)
                         .stream()
                         .flatMap(Pointer::objects)
+                        .filter(obj -> obj.getObject().isFunctional())
                         .map(csManager::getArrayIndex)
                         .flatMap(ArrayIndex::objects)));
     }
@@ -290,6 +293,7 @@ public class PointerAnalysisResultImpl extends AbstractResultHolder
         }
         return removeContexts(csManager.getCSObjsOf(array)
                 .stream()
+                .filter(obj -> obj.getObject().isFunctional())
                 .map(csManager::getArrayIndex)
                 .flatMap(ArrayIndex::objects));
     }

--- a/src/main/java/pascal/taie/analysis/pta/toolkit/mahjong/FieldPointsToGraph.java
+++ b/src/main/java/pascal/taie/analysis/pta/toolkit/mahjong/FieldPointsToGraph.java
@@ -55,20 +55,16 @@ class FieldPointsToGraph {
                 .filter(instanceField -> isConcerned(instanceField.getType()))
                 .forEach(instanceField -> {
                     Obj baseObj = instanceField.getBase().getObject();
-                    if (baseObj.isFunctional()) {
-                        JField jField = instanceField.getField();
-                        Set<Obj> pts = pta.getPointsToSet(baseObj, jField);
-                        addFieldPointsTo(baseObj, factory.get(jField), pts);
-                    }
+                    JField jField = instanceField.getField();
+                    Set<Obj> pts = pta.getPointsToSet(baseObj, jField);
+                    addFieldPointsTo(baseObj, factory.get(jField), pts);
                 });
         pta.getArrayIndexes().parallelStream()
                 .filter(arrayIndex -> isConcerned(arrayIndex.getType()))
                 .forEach(arrayIndex -> {
                     Obj array = arrayIndex.getArray().getObject();
-                    if (array.isFunctional()) {
-                        Set<Obj> pts = pta.getPointsToSet(array);
-                        addFieldPointsTo(array, factory.getArrayIndex(), pts);
-                    }
+                    Set<Obj> pts = pta.getPointsToSet(array);
+                    addFieldPointsTo(array, factory.getArrayIndex(), pts);
                 });
     }
 

--- a/src/test/java/pascal/taie/analysis/pta/PointerAnalysisResultTest.java
+++ b/src/test/java/pascal/taie/analysis/pta/PointerAnalysisResultTest.java
@@ -1,0 +1,53 @@
+package pascal.taie.analysis.pta;
+
+import org.junit.jupiter.api.Test;
+import pascal.taie.World;
+import pascal.taie.analysis.Tests;
+import pascal.taie.analysis.pta.core.heap.Obj;
+import pascal.taie.ir.exp.Var;
+import pascal.taie.language.classes.ClassHierarchy;
+import pascal.taie.language.classes.JField;
+import pascal.taie.language.classes.JMethod;
+import pascal.taie.language.classes.MethodNames;
+import pascal.taie.language.type.ArrayType;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PointerAnalysisResultTest {
+
+    @Test
+    void testNonFunctionalArrayIndexes() {
+        Tests.testPTA(false, "basic", "ZeroLengthArray", "cs:1-obj-1h");
+        PointerAnalysisResult pta = World.get().getResult(PointerAnalysis.ID);
+        ClassHierarchy hierarchy = World.get().getClassHierarchy();
+
+        int before = pta.getArrayIndexes().size();
+
+        // Container.EMPTY = new A[0]
+        JField field = hierarchy.getField("<Container: A[] EMPTY>");
+        Set<Obj> pts = pta.getPointsToSet(field);
+        assertTrue(pts.stream().noneMatch(Obj::isFunctional));
+
+        // public Container() { data = EMPTY; }
+        JMethod constructor = Objects.requireNonNull(hierarchy.getClass("Container"))
+                .getDeclaredMethod(MethodNames.INIT);
+        Collection<Var> vars = Objects.requireNonNull(constructor)
+                .getIR().getVars().stream()
+                .filter(v -> v.getType() instanceof ArrayType)
+                .collect(Collectors.toUnmodifiableSet());
+
+        // Ensure these operations does not trigger ArrayIndex creation
+        pts.forEach(pta::getPointsToSet);
+        // This relies on the fact that `index` variables are ignored by pta result
+        vars.forEach(base -> pta.getPointsToSet(base, (Var) null));
+
+        int after = pta.getArrayIndexes().size();
+        assertEquals(before, after);
+    }
+}

--- a/src/test/java/pascal/taie/analysis/pta/toolkit/mahjong/MahjongTest.java
+++ b/src/test/java/pascal/taie/analysis/pta/toolkit/mahjong/MahjongTest.java
@@ -22,7 +22,6 @@
 
 package pascal.taie.analysis.pta.toolkit.mahjong;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import pascal.taie.Main;
 import pascal.taie.World;
@@ -49,9 +48,8 @@ class MahjongTest {
         assertEquals(0, countRelevantStmts(mayFailCastResult));
     }
 
-    @RepeatedTest(100)
+    @Test
     void testMultipleZeroLengthArrays() {
-        // This bug appears non-deterministically
         assertDoesNotThrow(() -> Main.main("-acp", MAHJONG,
                 "-m", "MultipleZeroLengthArrays",
                 "-a", "pta=advanced:mahjong"));

--- a/src/test/java/pascal/taie/analysis/pta/toolkit/mahjong/MahjongTest.java
+++ b/src/test/java/pascal/taie/analysis/pta/toolkit/mahjong/MahjongTest.java
@@ -1,0 +1,72 @@
+/*
+ * Tai-e: A Static Analysis Framework for Java
+ *
+ * Copyright (C) 2022 Tian Tan <tiantan@nju.edu.cn>
+ * Copyright (C) 2022 Yue Li <yueli@nju.edu.cn>
+ *
+ * This file is part of Tai-e.
+ *
+ * Tai-e is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * Tai-e is distributed in the hope that it will be useful,but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Tai-e. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package pascal.taie.analysis.pta.toolkit.mahjong;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import pascal.taie.Main;
+import pascal.taie.World;
+import pascal.taie.analysis.StmtResult;
+import pascal.taie.analysis.pta.PointerAnalysis;
+import pascal.taie.analysis.pta.PointerAnalysisResult;
+import pascal.taie.analysis.pta.client.MayFailCast;
+import pascal.taie.language.classes.ClassMember;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MahjongTest {
+
+    private static final String MAHJONG = "src/test/resources/pta/toolkit/mahjong/";
+
+    @Test
+    void testFPG() {
+        Main.main("-acp", MAHJONG,
+                "-m", "Mahjong",
+                "-a", "pta=advanced:mahjong",
+                "-a", "may-fail-cast");
+        StmtResult<Boolean> mayFailCastResult = World.get().getResult(MayFailCast.ID);
+        assertEquals(0, countRelevantStmts(mayFailCastResult));
+    }
+
+    @RepeatedTest(100)
+    void testMultipleZeroLengthArrays() {
+        // This bug appears non-deterministically
+        assertDoesNotThrow(() -> Main.main("-acp", MAHJONG,
+                "-m", "MultipleZeroLengthArrays",
+                "-a", "pta=advanced:mahjong"));
+    }
+
+    /**
+     * @param mayFailCastResult the result of the may-fail-cast analysis
+     * @return the number of casts that may fail in app
+     */
+    private static long countRelevantStmts(StmtResult<Boolean> mayFailCastResult) {
+        PointerAnalysisResult pta = World.get().getResult(PointerAnalysis.ID);
+        return pta.getCallGraph().reachableMethods()
+                .filter(ClassMember::isApplication)
+                .flatMap(x -> x.getIR().stmts())
+                .filter(mayFailCastResult::getResult)
+                .count();
+    }
+}

--- a/src/test/resources/pta/toolkit/mahjong/Mahjong.java
+++ b/src/test/resources/pta/toolkit/mahjong/Mahjong.java
@@ -1,0 +1,29 @@
+public class Mahjong {
+    public static void main(String[] args) {
+        A x = new A();
+        A y = new A();
+        A z = new A();
+        x.f = new B();
+        y.f = new C();
+        z.f = new C();
+        A a = z.f;
+        a.foo();
+        C c = (C) a;
+    }
+}
+
+class A {
+    A f;
+    void foo() {
+    }
+}
+
+class B extends A {
+    void foo() {
+    }
+}
+
+class C extends A {
+    void foo() {
+    }
+}

--- a/src/test/resources/pta/toolkit/mahjong/MultipleZeroLengthArrays.java
+++ b/src/test/resources/pta/toolkit/mahjong/MultipleZeroLengthArrays.java
@@ -1,0 +1,62 @@
+public class MultipleZeroLengthArrays {
+    public static void main(String[] args) {
+        Object o = loadZeroLengthArrays();
+    }
+
+    public static Object loadZeroLengthArrays() {
+        Object res = "aaa";
+        Object[] arr_a = new Object[0]; res = arr_a[0];
+        Object[] arr_A = new Object[0]; res = arr_A[0];
+        Object[] arr_b = new Object[0]; res = arr_b[0];
+        Object[] arr_B = new Object[0]; res = arr_B[0];
+        Object[] arr_c = new Object[0]; res = arr_c[0];
+        Object[] arr_C = new Object[0]; res = arr_C[0];
+        Object[] arr_d = new Object[0]; res = arr_d[0];
+        Object[] arr_D = new Object[0]; res = arr_D[0];
+        Object[] arr_e = new Object[0]; res = arr_e[0];
+        Object[] arr_E = new Object[0]; res = arr_E[0];
+        Object[] arr_f = new Object[0]; res = arr_f[0];
+        Object[] arr_F = new Object[0]; res = arr_F[0];
+        Object[] arr_g = new Object[0]; res = arr_g[0];
+        Object[] arr_G = new Object[0]; res = arr_G[0];
+        Object[] arr_h = new Object[0]; res = arr_h[0];
+        Object[] arr_H = new Object[0]; res = arr_H[0];
+        Object[] arr_i = new Object[0]; res = arr_i[0];
+        Object[] arr_I = new Object[0]; res = arr_I[0];
+        Object[] arr_j = new Object[0]; res = arr_j[0];
+        Object[] arr_J = new Object[0]; res = arr_J[0];
+        Object[] arr_k = new Object[0]; res = arr_k[0];
+        Object[] arr_K = new Object[0]; res = arr_K[0];
+        Object[] arr_l = new Object[0]; res = arr_l[0];
+        Object[] arr_L = new Object[0]; res = arr_L[0];
+        Object[] arr_m = new Object[0]; res = arr_m[0];
+        Object[] arr_M = new Object[0]; res = arr_M[0];
+        Object[] arr_n = new Object[0]; res = arr_n[0];
+        Object[] arr_N = new Object[0]; res = arr_N[0];
+        Object[] arr_o = new Object[0]; res = arr_o[0];
+        Object[] arr_O = new Object[0]; res = arr_O[0];
+        Object[] arr_p = new Object[0]; res = arr_p[0];
+        Object[] arr_P = new Object[0]; res = arr_P[0];
+        Object[] arr_q = new Object[0]; res = arr_q[0];
+        Object[] arr_Q = new Object[0]; res = arr_Q[0];
+        Object[] arr_r = new Object[0]; res = arr_r[0];
+        Object[] arr_R = new Object[0]; res = arr_R[0];
+        Object[] arr_s = new Object[0]; res = arr_s[0];
+        Object[] arr_S = new Object[0]; res = arr_S[0];
+        Object[] arr_t = new Object[0]; res = arr_t[0];
+        Object[] arr_T = new Object[0]; res = arr_T[0];
+        Object[] arr_u = new Object[0]; res = arr_u[0];
+        Object[] arr_U = new Object[0]; res = arr_U[0];
+        Object[] arr_v = new Object[0]; res = arr_v[0];
+        Object[] arr_V = new Object[0]; res = arr_V[0];
+        Object[] arr_w = new Object[0]; res = arr_w[0];
+        Object[] arr_W = new Object[0]; res = arr_W[0];
+        Object[] arr_x = new Object[0]; res = arr_x[0];
+        Object[] arr_X = new Object[0]; res = arr_X[0];
+        Object[] arr_y = new Object[0]; res = arr_y[0];
+        Object[] arr_Y = new Object[0]; res = arr_Y[0];
+        Object[] arr_z = new Object[0]; res = arr_z[0];
+        Object[] arr_Z = new Object[0]; res = arr_Z[0];
+        return res;
+    }
+}


### PR DESCRIPTION
# Inconsistency

The current implementation of Mahjong is inconsistent with its paper. According to [1], if the field `f` of an object `oi` may point to another object `oj`, then there is an edge from `oi` to `oj` with label `f` added to the FieldPointsToGraph. However, currently Mahjong builds edges only for those fields that are loaded in the analyzed program.

# MockObjs

ConcurrentModificationException may be thrown when building the FieldPointsToGraph.
In #140 an optimization targeting zero length arrays is introduced by allocating non-functional MockObjs for 0 sized arrays, whose array indices should never point to any objects. Currently FieldPointsToGraph does not check for this situation.

[1] T. Tan, Y. Li, and J. Xue, “Efficient and precise points-to analysis: modeling the heap by merging equivalent automata,” in Proceedings of the 38th ACM SIGPLAN Conference on Programming Language Design and Implementation, in PLDI 2017. New York, NY, USA: Association for Computing Machinery, 2017, pp. 278–291. doi: [10.1145/3062341.3062360](https://doi.org/10.1145/3062341.3062360).