### PR TITLE
Fix NPE in Zipper-e pre-analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Pointer analysis
   - Add special handling for zero-length arrays to enhance PTA precision.
 
+### Fixes
+- Fix NPE in Zipper-e pre-analysis.
+
 ## [0.5.1] - 2024-12-31
 
 ### New Features

--- a/src/main/java/pascal/taie/analysis/pta/toolkit/zipper/Zipper.java
+++ b/src/main/java/pascal/taie/analysis/pta/toolkit/zipper/Zipper.java
@@ -186,7 +186,10 @@ public class Zipper {
         if (isExpress) {
             int accPts = 0;
             for (JMethod m : pcms) {
-                accPts += methodPts.get(m).intValue();
+                MutableInt mPtsSize = methodPts.get(m);
+                if (mPtsSize != null) {
+                    accPts += mPtsSize.intValue();
+                }
             }
             if (accPts > pcmThreshold) {
                 // clear precision-critical method group whose accumulative


### PR DESCRIPTION
This PR fixes #163.
Zipper-e uses a map `methodPts` to maintain accumulative points-to size of each methods. However, when all the points-to sets of all the `Var` in a method are empty, `methodPts` will not have a entry for that method.
https://github.com/pascal-lab/Tai-e/blob/0f4bcf408de715030080e32f44c60d6aab8f660a/src/main/java/pascal/taie/analysis/pta/toolkit/zipper/Zipper.java#L137-L145
The usage of `methodPts` lacks a null check, which could cause NPE.
https://github.com/pascal-lab/Tai-e/blob/0f4bcf408de715030080e32f44c60d6aab8f660a/src/main/java/pascal/taie/analysis/pta/toolkit/zipper/Zipper.java#L186-L196

Based on performance considerations, add null checks on the usage side of `methodPts` and keep the original optimization for empty points-to sets.