### PR TITLE
Add a format check for command-line arguments

### DIFF
--- a/src/main/java/pascal/taie/config/PlanConfig.java
+++ b/src/main/java/pascal/taie/config/PlanConfig.java
@@ -140,8 +140,8 @@ public class PlanConfig {
             if (!keyValue.isBlank()) {
                 int i = keyValue.indexOf(':'); // split keyValue
                 if (i == -1) {
-                    throw new IllegalArgumentException("Missing value for key '" + keyValue
-                    + "', Expected format is 'key:value'");
+                    throw new IllegalArgumentException("Invalid argument format '" + keyValue
+                    + "'. Expected format: 'key:value'");
                 }
                 joiner.add(keyValue.substring(0, i) + ": "
                         + keyValue.substring(i + 1));

--- a/src/main/java/pascal/taie/config/PlanConfig.java
+++ b/src/main/java/pascal/taie/config/PlanConfig.java
@@ -139,6 +139,10 @@ public class PlanConfig {
         for (String keyValue : optValue.split(";")) {
             if (!keyValue.isBlank()) {
                 int i = keyValue.indexOf(':'); // split keyValue
+                if (i == -1) {
+                    throw new IllegalArgumentException("Missing value for key '" + keyValue
+                    + "', Expected format is 'key:value'");
+                }
                 joiner.add(keyValue.substring(0, i) + ": "
                         + keyValue.substring(i + 1));
             }


### PR DESCRIPTION
This patch improves the argument parsing logic to provide users with a clearer, more actionable error message when they provide an argument key without its required value.

### Before

Previously, when a user provided an argument without its value (e.g., `cs` instead of `cs:ci`) the application would crash due to an unhandled `StringIndexOutOfBoundsException`:
<img width="3827" height="1822" alt="image" src="https://github.com/user-attachments/assets/549e2659-6789-4dfb-89cc-a240a2fe0a38" />
This error message was not intuitive and didn't guide the user on how to fix their input.

### After

With this patch, Tai-e now proactively checks the format of the arguments. If a value is missing, it raises a helpful `IllegalArgumentException` with a clear message explaining the correct key:value format (e.g. `Missing value for key 'ci', Expected format is 'key:value'`). This informs the user how to resolve the issue.

<img width="3829" height="1773" alt="image" src="https://github.com/user-attachments/assets/7605f087-4397-4332-a73c-4b9bb9ded938" />