### PR TITLE
Fix SideEffectAnalysis incorrect behavior when `only-app` is false

### DIFF
--- a/src/main/java/pascal/taie/analysis/sideeffect/TopologicalSolver.java
+++ b/src/main/java/pascal/taie/analysis/sideeffect/TopologicalSolver.java
@@ -112,10 +112,11 @@ class TopologicalSolver {
     }
 
     private boolean isRelevant(Obj obj) {
-        if (onlyApp && obj.getContainerMethod().isPresent()) {
-            return obj.getContainerMethod().get().isApplication();
+        if (onlyApp) {
+            return obj.getContainerMethod().isPresent()
+                    && obj.getContainerMethod().get().isApplication();
         }
-        return false;
+        return true;
     }
 
     private static Map<JMethod, Set<Obj>> computeSCCDirectMods(

--- a/src/test/java/pascal/taie/analysis/sideeffect/SideEffectTest.java
+++ b/src/test/java/pascal/taie/analysis/sideeffect/SideEffectTest.java
@@ -24,7 +24,14 @@ package pascal.taie.analysis.sideeffect;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import pascal.taie.Main;
+import pascal.taie.World;
 import pascal.taie.analysis.Tests;
+
+import java.util.LongSummaryStatistics;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SideEffectTest {
 
@@ -34,6 +41,21 @@ public class SideEffectTest {
         Tests.testMain(mainClass, CLASS_PATH, "side-effect",
                 "-a", "pta=implicit-entries:false",
                 "-a", "cg=algorithm:pta");
+    }
+
+    private static SideEffect runSideEffect(String mainClass, boolean onlyApp) {
+        Main.main("-cp", CLASS_PATH,
+                "-m", mainClass,
+                "-a", "side-effect=only-app:" + onlyApp);
+        return World.get().getResult(SideEffectAnalysis.ID);
+    }
+
+    private LongSummaryStatistics summarize(SideEffect sideEffect) {
+        return World.get().getClassHierarchy().allClasses()
+                .flatMap(c -> c.getDeclaredMethods().stream())
+                .map(sideEffect::getModifiedObjects)
+                .mapToLong(Set::size)
+                .summaryStatistics();
     }
 
     @ParameterizedTest
@@ -59,5 +81,37 @@ public class SideEffectTest {
     })
     void test(String mainClass) {
         testSideEffect(mainClass);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "StaticStore",
+            "SimpleCases",
+            "LinkedList",
+            "BubbleSort",
+            "PureTest",
+            "ConstructorTest",
+            "PrimitiveTest",
+            "Arrays",
+            "SideEffects",
+            "Globals",
+            "Inheritance",
+            "InterProc",
+            "Recursion",
+            "Loops",
+            "Null",
+            "OOP",
+            "Milanova",
+            "PolyLoop"
+    })
+    void testGlobal(String mainClass) {
+        // when only-app is set to false, the result should be no smaller
+        SideEffect appResult = runSideEffect(mainClass, true);
+        LongSummaryStatistics appSummary = summarize(appResult);
+
+        SideEffect globalResult = runSideEffect(mainClass, false);
+        LongSummaryStatistics globalSummary = summarize(globalResult);
+
+        assertTrue(appSummary.getMax() <= globalSummary.getMax());
     }
 }


### PR DESCRIPTION
When the `only-app` flag for the side-effect analysis (also known as mod-ref analysis) is set to false, Tai-e excludes all the objects no matter whether they are not allocated in the application code or not.

https://github.com/pascal-lab/Tai-e/blob/21118b5d37ebc2e9cf6bffb6cc6c98b74b8ea268/src/main/java/pascal/taie/analysis/sideeffect/TopologicalSolver.java#L114-L119

When `only-app` is `false`, function `isRelevant` always returns `false`.