### PR TITLE
Remove a redundant PTS updating

### DIFF
--- a/src/main/java/pascal/taie/analysis/pta/plugin/reflection/ReflectiveActionModel.java
+++ b/src/main/java/pascal/taie/analysis/pta/plugin/reflection/ReflectiveActionModel.java
@@ -255,7 +255,7 @@ public class ReflectiveActionModel extends AnalysisModelPlugin {
             Type baseType = CSObjs.toType(obj);
             if (baseType != null && !(baseType instanceof VoidType)) {
                 ArrayType arrayType = typeSystem.getArrayType(baseType, 1);
-                CSObj csNewArray = newReflectiveObj(context, invoke, arrayType);
+                newReflectiveObj(context, invoke, arrayType);
                 allTargets.put(invoke, arrayType);
             }
         });

--- a/src/main/java/pascal/taie/analysis/pta/plugin/reflection/ReflectiveActionModel.java
+++ b/src/main/java/pascal/taie/analysis/pta/plugin/reflection/ReflectiveActionModel.java
@@ -256,7 +256,6 @@ public class ReflectiveActionModel extends AnalysisModelPlugin {
             if (baseType != null && !(baseType instanceof VoidType)) {
                 ArrayType arrayType = typeSystem.getArrayType(baseType, 1);
                 CSObj csNewArray = newReflectiveObj(context, invoke, arrayType);
-                solver.addVarPointsTo(context, result, csNewArray);
                 allTargets.put(invoke, arrayType);
             }
         });


### PR DESCRIPTION
In `ReflectiveActionModel`'s `arrayNewInstance`, the code first calls `newReflectiveObj(context, invoke, arrayType)` to create a reflective object for the array, and then calls `solver.addVarPointsTo(context, result, csNewArray)` to make the `result` points to this newly allocated object:
https://github.com/pascal-lab/Tai-e/blob/21118b5d37ebc2e9cf6bffb6cc6c98b74b8ea268/src/main/java/pascal/taie/analysis/pta/plugin/reflection/ReflectiveActionModel.java#L258-L259
However, `newReflectiveObj` has already done the updation of the points-to set of `result` (Line 156), and it also performs a null-check on `result` to ensure that invocation does contain a left-value.
https://github.com/pascal-lab/Tai-e/blob/21118b5d37ebc2e9cf6bffb6cc6c98b74b8ea268/src/main/java/pascal/taie/analysis/pta/plugin/reflection/ReflectiveActionModel.java#L149-L159

Therefore, I think https://github.com/pascal-lab/Tai-e/blob/21118b5d37ebc2e9cf6bffb6cc6c98b74b8ea268/src/main/java/pascal/taie/analysis/pta/plugin/reflection/ReflectiveActionModel.java#L259 is **redundant** (because `newReflectiveObj` will add the points-to relation if `result` is not null) and **dangerous** (if the `result` is null due to some rare corner cases).

Is simply removing it safe? I am not sure if there is any special case that I ignore.