### PR TITLE
Fix the detection of jar files in BenchmarkRunner

### DIFF
--- a/src/test/java/pascal/taie/analysis/pta/BenchmarkRunner.java
+++ b/src/test/java/pascal/taie/analysis/pta/BenchmarkRunner.java
@@ -128,6 +128,6 @@ public class BenchmarkRunner {
     }
 
     private static boolean isJar(File file) {
-        return file.getName().endsWith(".jar");
+        return !file.isDirectory() && file.getName().endsWith(".jar");
     }
 }

--- a/src/test/java/pascal/taie/analysis/pta/BenchmarkRunner.java
+++ b/src/test/java/pascal/taie/analysis/pta/BenchmarkRunner.java
@@ -128,6 +128,6 @@ public class BenchmarkRunner {
     }
 
     private static boolean isJar(File file) {
-        return !file.isDirectory() && file.getName().endsWith(".jar");
+        return file.isFile() && file.getName().endsWith(".jar");
     }
 }


### PR DESCRIPTION
Files whose names end with '.jar' is not necessarily a jar file (when they are actually directories).

https://github.com/pascal-lab/Tai-e/blob/359eb634cce81be50d5b5aa3f1920fe3296bcfc6/src/test/java/pascal/taie/analysis/pta/BenchmarkRunner.java#L131