### PR TITLE
Add docs for '--pre-build-ir' option

### DIFF
--- a/docs/en/command-line-options.adoc
+++ b/docs/en/command-line-options.adoc
@@ -65,10 +65,11 @@ These options decide the analyses to be executed and their behaviors. We divided
 
 * Build IR in advance (--pre-build-ir)
 ** Build IRs for all available methods before starting any analyses.
+** Without this option, IRs are built on-demand as they are required by analyses, intermingling analysis and IR building times. To accurately measure analysis time excluding IR building overhead, enable this option to build all IRs before analysis begins.
 
 * Analysis scope (-scope): `-scope <scope>`
 ** _Default value_: `APP`
-** Specify the analysis scope for class and method analyses.There are three valid choices:
+** Specify the analysis scope for class and method analyses. There are three valid choices:
 *** `APP`: application classes only
 *** `ALL`: all classes
 *** `REACHABLE`: classes that are reachable in the call graph (this scope requires analysis `cg`, i.e., call graph construction)


### PR DESCRIPTION
For #181.

Currently, Tai-e has issues with mixed timing across different components that are difficult to distinguish, such as:

* **Frontend and analysis time interweaving**: For example, when `--pre-build-ir` is not enabled, if running analysis `-a pta`, the pointer analysis (pta) time will include IR building time.

* **Analysis time interweaving**: For example, when using `-a cg=algorithm:pta --pre-build-ir` to specify using pointer analysis to build the call graph, the cg analysis runtime shows 0 (`cg finishes, elapsed time: 0.00s`) (data source: https://github.com/pascal-lab/Tai-e/issues/95#issuecomment-2034530679), because pta and cg are executed on-the-fly, and cg's time is counted in pta.

For the latter case, since some analyses naturally interweave (e.g., pta depends on cg), we won't discuss this scenario for now.

For the former case, since frontend phase is currently one of the more time-consuming parts of the entire execution, if users are unaware of this situation (when `--pre-build-ir` is not enabled), they might mistakenly think the default PTA is slow (due to including IR building time). Therefore, this PR adds documentation to explain this issue.