### PR TITLE
Fix javadoc for `Exp.getUses()` and `Stmt.getUses()`

### DIFF
--- a/src/main/java/pascal/taie/ir/exp/Exp.java
+++ b/src/main/java/pascal/taie/ir/exp/Exp.java
@@ -38,7 +38,7 @@ public interface Exp extends Serializable {
     Type getType();
 
     /**
-     * @return a list of expressions which are used by (contained in) this Exp.
+     * @return a set of expressions which are used by (contained in) this Exp.
      */
     default Set<RValue> getUses() {
         return Set.of();

--- a/src/main/java/pascal/taie/ir/stmt/Stmt.java
+++ b/src/main/java/pascal/taie/ir/stmt/Stmt.java
@@ -58,7 +58,7 @@ public interface Stmt extends Indexable, Serializable {
     Optional<LValue> getDef();
 
     /**
-     * @return a list of right-value expressions used in this Stmt.
+     * @return a set of right-value expressions used in this Stmt.
      */
     Set<RValue> getUses();
 


### PR DESCRIPTION
The return types of `Stmt.getUses()` and `Exp.getUses()` have changed from `List<RValue>` to `Set<RValue>` in 36b6f1d, yet the corresponding javadocs remain unchanged.

This PR simply fixes the mismatch between the javadocs and the method signature.