### PR TITLE
Issue errors when checkstyle detects an violation in GitHub CI

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEW_DOG_TOKEN }}
         run: |
-          reviewdog -reporter=github-pr-review -runners=checkstyle
+          reviewdog -reporter=github-check -runners=checkstyle

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,0 +1,28 @@
+name: StyleCheck
+on:
+  push:
+  pull_request:
+  workflow_dispatch: # add manual trigger button
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - uses: reviewdog/action-setup@d8edfce3dd5e1ec6978745e801f9c50b5ef80252
+        with:
+          reviewdog_version: latest
+
+      - name: Run reviewdog
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEW_DOG_TOKEN }}
+        run: |
+          reviewdog -reporter=github-pr-review -runners=checkstyle

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -17,6 +17,13 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+
       - uses: reviewdog/action-setup@d8edfce3dd5e1ec6978745e801f9c50b5ef80252
         with:
           reviewdog_version: latest

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,0 +1,5 @@
+runner:
+  checkstyle:
+    cmd: ./gradlew checkstyleMain checkstyleTest
+    format: checkstyle
+    level: error

--- a/buildSrc/src/main/kotlin/checkstyle.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/checkstyle.conventions.gradle.kts
@@ -8,10 +8,12 @@ tasks.findByName("testClasses")?.finalizedBy("checkstyleTest")
 
 // custom the report format
 checkstyle {
-    isShowViolations = false
     if (System.getenv("CI") == "true") {
+        isShowViolations = true
         isIgnoreFailures = false
         maxWarnings = 0
+    } else {
+        isShowViolations = true
     }
 }
 tasks.withType<Checkstyle> {

--- a/buildSrc/src/main/kotlin/checkstyle.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/checkstyle.conventions.gradle.kts
@@ -9,6 +9,10 @@ tasks.findByName("testClasses")?.finalizedBy("checkstyleTest")
 // custom the report format
 checkstyle {
     isShowViolations = false
+    if (System.getenv("CI") == "true") {
+        isIgnoreFailures = false
+        maxWarnings = 0
+    }
 }
 tasks.withType<Checkstyle> {
     // only xml need

--- a/buildSrc/src/main/kotlin/checkstyle.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/checkstyle.conventions.gradle.kts
@@ -8,13 +8,7 @@ tasks.findByName("testClasses")?.finalizedBy("checkstyleTest")
 
 // custom the report format
 checkstyle {
-    if (System.getenv("CI") == "true") {
-        isShowViolations = true
-        isIgnoreFailures = false
-        maxWarnings = 0
-    } else {
-        isShowViolations = true
-    }
+    isShowViolations = false
 }
 tasks.withType<Checkstyle> {
     // only xml need

--- a/src/test/java/pascal/taie/analysis/pta/PointerAnalysisResultTest.java
+++ b/src/test/java/pascal/taie/analysis/pta/PointerAnalysisResultTest.java
@@ -1,3 +1,25 @@
+/*
+ * Tai-e: A Static Analysis Framework for Java
+ *
+ * Copyright (C) 2022 Tian Tan <tiantan@nju.edu.cn>
+ * Copyright (C) 2022 Yue Li <yueli@nju.edu.cn>
+ *
+ * This file is part of Tai-e.
+ *
+ * Tai-e is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * Tai-e is distributed in the hope that it will be useful,but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Tai-e. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package pascal.taie.analysis.pta;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This PR configures checkstyle to issue errors instead of warnings when codeing-style violations are detected in GitHub CI, as in [this](https://github.com/jjppp/Tai-e/runs/49588133189) CI run, and fixes a coding-style violation related to the license header of a test driver.