### PR TITLE
Add performance monitoring (CPU and memory usage) functionality to Timer

### DIFF
--- a/src/main/java/pascal/taie/util/RuntimeInfoLogger.java
+++ b/src/main/java/pascal/taie/util/RuntimeInfoLogger.java
@@ -87,7 +87,7 @@ public class RuntimeInfoLogger {
         int cpuCores = osBean.getAvailableProcessors();
         long memoryMB = osBean.getTotalMemorySize() / (1024 * 1024);
         logger.info("Available CPU cores: {}", cpuCores);
-        logger.info("Total memory (MB): {}", memoryMB);
+        logger.info("Total memory: {}MB", memoryMB);
     }
 
     /**

--- a/src/main/java/pascal/taie/util/RuntimeInfoLogger.java
+++ b/src/main/java/pascal/taie/util/RuntimeInfoLogger.java
@@ -64,6 +64,7 @@ public class RuntimeInfoLogger {
      */
     public static void logRuntimeInfo() {
         logEnvInfo();
+        logSystemInfo();
         logTaieInfo();
     }
 
@@ -75,6 +76,18 @@ public class RuntimeInfoLogger {
             String value = System.getProperty(key);
             logger.info("{}: {}", key, value);
         }
+    }
+
+    /**
+     * Logs system information such as the number of CPU cores and total memory size.
+     */
+    private static void logSystemInfo() {
+        var osBean = (com.sun.management.OperatingSystemMXBean)
+                java.lang.management.ManagementFactory.getOperatingSystemMXBean();
+        int cpuCores = osBean.getAvailableProcessors();
+        long memoryMB = osBean.getTotalMemorySize() / (1024 * 1024);
+        logger.info("Available CPU cores: {}", cpuCores);
+        logger.info("Total memory (MB): {}", memoryMB);
     }
 
     /**

--- a/src/main/java/pascal/taie/util/Timer.java
+++ b/src/main/java/pascal/taie/util/Timer.java
@@ -87,13 +87,12 @@ public class Timer {
      * @param taskName name of the task
      */
     public static <T> T runAndCount(Supplier<T> task, String taskName, Level level) {
-        logger.info("{} starts ...", taskName);
+        logger.info("[{}] starts ...", taskName);
         Timer timer = new Timer(taskName);
         timer.start();
         T result = task.get();
         timer.stop();
-        logger.log(level, "{} finishes, elapsed time: {}", taskName,
-                String.format("%.2fs", timer.inSecond()));
+        logger.log(level, timer);
         return result;
     }
 


### PR DESCRIPTION
In the team meeting about #178, we revisited the user requirements, and we decided to create a lightweight performance monitoring solution focused on internal execution phases.

We directly added memory and CPU usage statistics functionality to the `Timer` utility class that was originally used for timing. 

Although this extends the functionality beyond what the `Timer` name suggests, since the code modifications are minimal, I'm still hesitating whether we should rename it (if we were to rename it, we might need to keep the Timer class and add a new class to maintain backward compatibility so that other branches using `Timer` wouldn't face breaking changes).

Below are the changes to the logs:

```diff
 os.name: Windows 11
 os.version: 10.0
 os.arch: amd64
+Available CPU cores: 32
+Total memory: 130767MB
 Tai-e Version: 0.5.2-SNAPSHOT
...
 Writing analysis plan to C:\Users\admin\Desktop\projects\Tai-e\output\tai-e-plan.yml
-WorldBuilder starts ...
+[WorldBuilder] starts ...
 The world cache mode is enabled.
 World cache not found in C:\Users\admin\Desktop\projects\Tai-e\cache\world-cache-163254446.bin
 Running the WorldBuilder ...
-[Build IR for all methods] elapsed time: 4.63s
+[Build IR for all methods] elapsed time: 3.53s; CPU usage: start 0.64%, peak 89.53%, end 36.64%; Memory usage: start 269MB, peak 2102MB, end 2195MB
-[Run the WorldBuilder] elapsed time: 8.76s
+[Run the WorldBuilder] elapsed time: 7.65s; CPU usage: start 0.00%, peak 89.53%, end 25.48%; Memory usage: start 87MB, peak 2582MB, end 1497MB
 Saving the world cache to C:\Users\admin\Desktop\projects\Tai-e\cache\world-cache-163254446.bin
-[Save the world cache] elapsed time: 2.05s
+[Save the world cache] elapsed time: 2.03s; CPU usage: start 25.48%, peak 25.48%, end 1.68%; Memory usage: start 1497MB, peak 1817MB, end 1817MB
 5729 classes with 55010 methods in the world
-WorldBuilder finishes, elapsed time: 10.82s
+[WorldBuilder] elapsed time: 9.86s; CPU usage: start 0.00%, peak 89.53%, end 1.68%; Memory usage: start 87MB, peak 2518MB, end 1817MB
-pta starts ...
+[pta] starts ...
 Using reflection log from C:\Users\admin\Desktop\projects\Tai-e\java-benchmarks\dacapo-2006\antlr-refl.log
-[Pointer analysis] elapsed time: 1.25s
+[Pointer analysis] elapsed time: 1.38s; CPU usage: start 1.68%, peak 2.98%, end 2.98%; Memory usage: start 1835MB, peak 2321MB, end 2512MB
...
-pta finishes, elapsed time: 1.67s
+[pta] elapsed time: 1.88s; CPU usage: start 1.68%, peak 2.98%, end 2.07%; Memory usage: start 1817MB, peak 2272MB, end 2704MB
-may-fail-cast starts ...
+[may-fail-cast] starts ...
 #may-fail-cast: found 1050 in 6924 reachable relevant Stmts
 #may-fail-cast: found 279 in 1861 reachable relevant Stmts (app)
-may-fail-cast finishes, elapsed time: 0.02s
+[may-fail-cast] elapsed time: 0.05s; CPU usage: start 2.07%, peak 2.07%, end 2.07%; Memory usage: start 2704MB, peak 2704MB, end 2704MB
-poly-call starts ...
+[poly-call] starts ...
 #poly-call: found 1992 in 32673 reachable relevant Stmts
 #poly-call: found 849 in 16855 reachable relevant Stmts (app)
-poly-call finishes, elapsed time: 0.02s
+[poly-call] elapsed time: 0.08s; CPU usage: start 2.07%, peak 2.07%, end 2.07%; Memory usage: start 2704MB, peak 2704MB, end 2704MB
-Tai-e finishes, elapsed time: 12.61s
+[Tai-e] elapsed time: 12.66s; CPU usage: start 0.00%, peak 89.53%, end 2.07%; Memory usage: start 68MB, peak 2704MB, end 2704MB

```