### PR TITLE
Improve the performance of `Obj.getType()` by caching `Obj`'s type

### DIFF
--- a/src/main/java/pascal/taie/analysis/pta/core/heap/ConstantObj.java
+++ b/src/main/java/pascal/taie/analysis/pta/core/heap/ConstantObj.java
@@ -36,12 +36,8 @@ public class ConstantObj extends Obj {
     private final ReferenceLiteral value;
 
     ConstantObj(ReferenceLiteral value) {
+        super(value.getType());
         this.value = value;
-    }
-
-    @Override
-    public Type getType() {
-        return value.getType();
     }
 
     @Override

--- a/src/main/java/pascal/taie/analysis/pta/core/heap/MergedObj.java
+++ b/src/main/java/pascal/taie/analysis/pta/core/heap/MergedObj.java
@@ -37,8 +37,6 @@ public class MergedObj extends Obj {
 
     private final String name;
 
-    private final Type type;
-
     /**
      * Set of objects represented by this merged object.
      */
@@ -51,7 +49,7 @@ public class MergedObj extends Obj {
     private Obj representative;
 
     public MergedObj(Type type, String name) {
-        this.type = type;
+        super(type);
         this.name = name;
     }
 
@@ -69,11 +67,6 @@ public class MergedObj extends Obj {
     @Override
     public Set<Obj> getAllocation() {
         return representedObjs;
-    }
-
-    @Override
-    public Type getType() {
-        return type;
     }
 
     @Override

--- a/src/main/java/pascal/taie/analysis/pta/core/heap/MockObj.java
+++ b/src/main/java/pascal/taie/analysis/pta/core/heap/MockObj.java
@@ -38,28 +38,21 @@ public class MockObj extends Obj {
 
     private final Object alloc;
 
-    private final Type type;
-
     private final JMethod container;
 
     private final boolean isFunctional;
 
     public MockObj(Descriptor desc, Object alloc, Type type,
                    JMethod container, boolean isFunctional) {
+        super(type);
         this.desc = desc;
         this.alloc = alloc;
-        this.type = type;
         this.container = container;
         this.isFunctional = isFunctional;
     }
 
     public Descriptor getDescriptor() {
         return desc;
-    }
-
-    @Override
-    public Type getType() {
-        return type;
     }
 
     @Override

--- a/src/main/java/pascal/taie/analysis/pta/core/heap/NewObj.java
+++ b/src/main/java/pascal/taie/analysis/pta/core/heap/NewObj.java
@@ -24,7 +24,6 @@ package pascal.taie.analysis.pta.core.heap;
 
 import pascal.taie.ir.stmt.New;
 import pascal.taie.language.classes.JMethod;
-import pascal.taie.language.type.ReferenceType;
 import pascal.taie.language.type.Type;
 
 import java.util.Optional;
@@ -37,12 +36,8 @@ public class NewObj extends Obj {
     private final New allocSite;
 
     NewObj(New allocSite) {
+        super(allocSite.getRValue().getType());
         this.allocSite = allocSite;
-    }
-
-    @Override
-    public ReferenceType getType() {
-        return allocSite.getRValue().getType();
     }
 
     @Override

--- a/src/main/java/pascal/taie/analysis/pta/core/heap/Obj.java
+++ b/src/main/java/pascal/taie/analysis/pta/core/heap/Obj.java
@@ -35,7 +35,13 @@ import java.util.Optional;
  */
 public abstract class Obj implements Indexable {
 
+    protected final Type type;
+
     private int index = -1;
+
+    protected Obj(Type type) {
+        this.type = type;
+    }
 
     void setIndex(int index) {
         if (this.index != -1) {
@@ -65,7 +71,9 @@ public abstract class Obj implements Indexable {
     /**
      * @return the type of the object.
      */
-    public abstract Type getType();
+    public Type getType() {
+        return type;
+    }
 
     /**
      * @return the allocation of the object.


### PR DESCRIPTION
For huge programs such as `columba-1.4` from [java-benchmarks](https://github.com/pascal-lab/java-benchmarks), most of the analysis time is spent on `TypeFilter` when propagating objects through the PFG, among which a major proportion is spent on the `Obj.getType()`.

Simply caching the type of the `Obj` using a field brings substantial speedup to the original Tai-e (comparing 85045624faf2a5211c9a35c28a30d8145aab1c8d to 064801b610f49b5ae90ea6e4addf61c415c68386). On my laptop (AMD Ryzen7 4800H 2.9GHz with 16G heap memory for JVM) this optimization saves 30% of the analysis time for `columba-1.4`.

https://github.com/pascal-lab/Tai-e/blob/85045624faf2a5211c9a35c28a30d8145aab1c8d/src/main/java/pascal/taie/analysis/pta/core/heap/Obj.java#L36-L44

The results are shown below (irrelevant lines are removed for clarity):

```diff
15c15
< Tai-e Commit: c2c9ebebc65724f79f38732976d58d10b2939a95
---
> Tai-e Commit: 064801b610f49b5ae90ea6e4addf61c415c68386
48c48
< [Pointer analysis] elapsed time: 178.86s
---
> [Pointer analysis] elapsed time: 253.08s
73c73
< pta finishes, elapsed time: 200.34s
---
> pta finishes, elapsed time: 272.84s
77c77
< may-fail-cast finishes, elapsed time: 0.09s
---
> may-fail-cast finishes, elapsed time: 0.10s
81,82c81,82
< poly-call finishes, elapsed time: 0.10s
< Tai-e finishes, elapsed time: 205.03s
---
> poly-call finishes, elapsed time: 0.09s
> Tai-e finishes, elapsed time: 279.17s
```

<details>

<summary>log file for gettype optimization(85045624faf2a5211c9a35c28a30d8145aab1c8d)</summary>

```
Analyzing columba-1.4
Tai-e starts ...
Output directory: /home/jjppp/Code/Project/Tai-e/output
Writing options to /home/jjppp/Code/Project/Tai-e/output/options.yml
Writing log to /home/jjppp/Code/Project/Tai-e/output/tai-e.log
java.version: 17.0.14
java.version.date: 2025-01-21
java.runtime.version: 17.0.14+7-LTS
java.vendor: Amazon.com Inc.
java.vendor.version: Corretto-17.0.14.7.1
os.name: Linux
os.version: 6.15.7-arch1-1
os.arch: amd64
Tai-e Version: 0.5.2-SNAPSHOT
Tai-e Commit: 064801b610f49b5ae90ea6e4addf61c415c68386
Writing analysis plan to /home/jjppp/Code/Project/Tai-e/output/tai-e-plan.yml
WorldBuilder starts ...
The world cache mode is enabled.
Loading the world cache from /home/jjppp/Code/Project/Tai-e/cache/world-cache-2032021125.bin
[Load the world cache] elapsed time: 5.94s
12404 classes with 115918 methods in the world
WorldBuilder finishes, elapsed time: 5.95s
pta starts ...
Using reflection log from /home/jjppp/Code/Project/Tai-e/java-benchmarks/columba/1.4/refl.log
Reflective target 'byte[]' for Class.forName is not found
Reflective target 'java.lang.String[]' for Class.forName is not found
Reflective caller class 'sun.nio.cs.AbstractCharsetProvider' is absent
Reflective target 'sun.security.pkcs.SignerInfo[]' for Class.forName is not found
Reflective target '<com.sun.crypto.provider.BlowfishCipher: void <init>()>' for Constructor.newInstance is not found
Reflective target '<com.sun.crypto.provider.SunJCE: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.Big5: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.Big5_HKSCS: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.EUC_CN: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.EUC_JP: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.EUC_KR: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.EUC_TW: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.ExtendedCharsets: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.GB18030: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.GBK: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.ISO2022_JP: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.ISO2022_KR: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.ISO_8859_3: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.Johab: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.MS1258: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.MS932: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.SJIS: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.TIS_620: void <init>()>' for Constructor.newInstance is not found
[Pointer analysis] elapsed time: 253.08s
Imprecise reflective calls:
[Array.newInstance]<org.codehaus.groovy.ast.ClassNode: org.codehaus.groovy.ast.ClassNode makeArray()>[9@L143] $r5 = invokestatic java.lang.reflect.Array.newInstance($r4, %intconst0), #targets: 2925
[Array.newInstance]<org.codehaus.groovy.runtime.MetaClassHelper: java.lang.Object makeArray(java.lang.Object,java.lang.Class,int)>[3@L644] $r2 = invokestatic java.lang.reflect.Array.newInstance(r3, length), #targets: 2925
[Class.newInstance]<java.awt.Toolkit: void loadAssistiveTechnologies()>[15@L771] invokevirtual r31.newInstance(), #targets: 1066
[Class.newInstance]<java.beans.Introspector: java.lang.Object instantiate(java.lang.Class,java.lang.String)>[9@L1460] $r9 = invokevirtual $r8.newInstance(), #targets: 1066
[Class.newInstance]<java.beans.Introspector: java.lang.Object instantiate(java.lang.Class,java.lang.String)>[16@L1471] $r7 = invokevirtual $r6.newInstance(), #targets: 1066
[Class.newInstance]<java.security.Provider$Service: java.lang.Object newInstanceGeneric(java.lang.Object)>[2@L1283] $r19 = invokevirtual $r1.newInstance(), #targets: 1066
[Class.newInstance]<java.util.logging.LogManager: void readConfiguration()>[6@L939] invokevirtual $r10.newInstance(), #targets: 1066
[Class.newInstance]<java.util.logging.LogManager: void readConfiguration()>[12@L943] invokevirtual $r27.newInstance(), #targets: 1066
[Class.newInstance]<java.util.logging.LogManager: void readConfiguration(java.io.InputStream)>[12@L1084] invokevirtual $r7.newInstance(), #targets: 1066
[Class.newInstance]<javax.xml.transform.FactoryFinder: java.lang.Object newInstance(java.lang.String,java.lang.ClassLoader,boolean,boolean)>[6@L166] r24 = invokevirtual $r2.newInstance(), #targets: 1066
[Class.newInstance]<org.columba.core.plugin.ExternalClassLoader: java.lang.Object instanciate(java.lang.String,java.lang.Object[])>[5@L-1] $r4 = invokevirtual $r2.newInstance(), #targets: 1066
[Class.newInstance]<org.python.core.PyBeanEventProperty: java.lang.Object getAdapter(java.lang.Object)>[7@L80] $r7 = invokevirtual $r6.newInstance(), #targets: 1066
[Class.newInstance]<org.xml.sax.helpers.NewInstance: java.lang.Object newInstance(java.lang.ClassLoader,java.lang.String)>[14@L60] $r3 = invokevirtual r4.newInstance(), #targets: 1066
-------------- Pointer analysis statistics: --------------
#var pointers:                38,2894 (insens) / 38,2894 (sens)
#objects:                     5,1227 (insens) / 5,1227 (sens)
#var points-to:               1,6755,1378 (insens) / 1,6755,1378 (sens)
#static field points-to:      5,4480 (sens)
#instance field points-to:    1,1034,9431 (sens)
#array points-to:             277,0268 (sens)
#reachable methods:           5,6594 (insens) / 5,6594 (sens)
#call graph edges:            42,5921 (insens) / 42,5921 (sens)
----------------------------------------
pta finishes, elapsed time: 272.84s
may-fail-cast starts ...
#may-fail-cast: found 10406 in 35697 reachable relevant Stmts
#may-fail-cast: found 4377 in 9886 reachable relevant Stmts (app)
may-fail-cast finishes, elapsed time: 0.10s
poly-call starts ...
#poly-call: found 17608 in 167606 reachable relevant Stmts
#poly-call: found 6550 in 72806 reachable relevant Stmts (app)
poly-call finishes, elapsed time: 0.09s
Tai-e finishes, elapsed time: 279.17s
```

</details>

<details>

<summary>log file for master(064801b610f49b5ae90ea6e4addf61c415c68386)</summary>

```
Analyzing columba-1.4
Tai-e starts ...
Output directory: /home/jjppp/Code/Project/Tai-e/output
Writing options to /home/jjppp/Code/Project/Tai-e/output/options.yml
Writing log to /home/jjppp/Code/Project/Tai-e/output/tai-e.log
java.version: 17.0.14
java.version.date: 2025-01-21
java.runtime.version: 17.0.14+7-LTS
java.vendor: Amazon.com Inc.
java.vendor.version: Corretto-17.0.14.7.1
os.name: Linux
os.version: 6.15.7-arch1-1
os.arch: amd64
Tai-e Version: 0.5.2-SNAPSHOT
Tai-e Commit: c2c9ebebc65724f79f38732976d58d10b2939a95
Writing analysis plan to /home/jjppp/Code/Project/Tai-e/output/tai-e-plan.yml
WorldBuilder starts ...
The world cache mode is enabled.
Loading the world cache from /home/jjppp/Code/Project/Tai-e/cache/world-cache-2032021125.bin
[Load the world cache] elapsed time: 4.33s
12404 classes with 115918 methods in the world
WorldBuilder finishes, elapsed time: 4.34s
pta starts ...
Using reflection log from /home/jjppp/Code/Project/Tai-e/java-benchmarks/columba/1.4/refl.log
Reflective target 'byte[]' for Class.forName is not found
Reflective target 'java.lang.String[]' for Class.forName is not found
Reflective caller class 'sun.nio.cs.AbstractCharsetProvider' is absent
Reflective target 'sun.security.pkcs.SignerInfo[]' for Class.forName is not found
Reflective target '<com.sun.crypto.provider.BlowfishCipher: void <init>()>' for Constructor.newInstance is not found
Reflective target '<com.sun.crypto.provider.SunJCE: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.Big5: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.Big5_HKSCS: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.EUC_CN: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.EUC_JP: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.EUC_KR: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.EUC_TW: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.ExtendedCharsets: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.GB18030: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.GBK: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.ISO2022_JP: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.ISO2022_KR: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.ISO_8859_3: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.Johab: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.MS1258: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.MS932: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.SJIS: void <init>()>' for Constructor.newInstance is not found
Reflective target '<sun.nio.cs.ext.TIS_620: void <init>()>' for Constructor.newInstance is not found
[Pointer analysis] elapsed time: 178.86s
Imprecise reflective calls:
[Array.newInstance]<org.codehaus.groovy.ast.ClassNode: org.codehaus.groovy.ast.ClassNode makeArray()>[9@L143] $r5 = invokestatic java.lang.reflect.Array.newInstance($r4, %intconst0), #targets: 2925
[Array.newInstance]<org.codehaus.groovy.runtime.MetaClassHelper: java.lang.Object makeArray(java.lang.Object,java.lang.Class,int)>[3@L644] $r2 = invokestatic java.lang.reflect.Array.newInstance(r3, length), #targets: 2925
[Class.newInstance]<java.awt.Toolkit: void loadAssistiveTechnologies()>[15@L771] invokevirtual r31.newInstance(), #targets: 1066
[Class.newInstance]<java.beans.Introspector: java.lang.Object instantiate(java.lang.Class,java.lang.String)>[9@L1460] $r9 = invokevirtual $r8.newInstance(), #targets: 1066
[Class.newInstance]<java.beans.Introspector: java.lang.Object instantiate(java.lang.Class,java.lang.String)>[16@L1471] $r7 = invokevirtual $r6.newInstance(), #targets: 1066
[Class.newInstance]<java.security.Provider$Service: java.lang.Object newInstanceGeneric(java.lang.Object)>[2@L1283] $r19 = invokevirtual $r1.newInstance(), #targets: 1066
[Class.newInstance]<java.util.logging.LogManager: void readConfiguration()>[6@L939] invokevirtual $r10.newInstance(), #targets: 1066
[Class.newInstance]<java.util.logging.LogManager: void readConfiguration()>[12@L943] invokevirtual $r27.newInstance(), #targets: 1066
[Class.newInstance]<java.util.logging.LogManager: void readConfiguration(java.io.InputStream)>[12@L1084] invokevirtual $r7.newInstance(), #targets: 1066
[Class.newInstance]<javax.xml.transform.FactoryFinder: java.lang.Object newInstance(java.lang.String,java.lang.ClassLoader,boolean,boolean)>[6@L166] r24 = invokevirtual $r2.newInstance(), #targets: 1066
[Class.newInstance]<org.columba.core.plugin.ExternalClassLoader: java.lang.Object instanciate(java.lang.String,java.lang.Object[])>[5@L-1] $r4 = invokevirtual $r2.newInstance(), #targets: 1066
[Class.newInstance]<org.python.core.PyBeanEventProperty: java.lang.Object getAdapter(java.lang.Object)>[7@L80] $r7 = invokevirtual $r6.newInstance(), #targets: 1066
[Class.newInstance]<org.xml.sax.helpers.NewInstance: java.lang.Object newInstance(java.lang.ClassLoader,java.lang.String)>[14@L60] $r3 = invokevirtual r4.newInstance(), #targets: 1066
-------------- Pointer analysis statistics: --------------
#var pointers:                38,2894 (insens) / 38,2894 (sens)
#objects:                     5,1227 (insens) / 5,1227 (sens)
#var points-to:               1,6755,1378 (insens) / 1,6755,1378 (sens)
#static field points-to:      5,4480 (sens)
#instance field points-to:    1,1034,9431 (sens)
#array points-to:             277,0268 (sens)
#reachable methods:           5,6594 (insens) / 5,6594 (sens)
#call graph edges:            42,5921 (insens) / 42,5921 (sens)
----------------------------------------
pta finishes, elapsed time: 200.34s
may-fail-cast starts ...
#may-fail-cast: found 10406 in 35697 reachable relevant Stmts
#may-fail-cast: found 4377 in 9886 reachable relevant Stmts (app)
may-fail-cast finishes, elapsed time: 0.09s
poly-call starts ...
#poly-call: found 17608 in 167606 reachable relevant Stmts
#poly-call: found 6550 in 72806 reachable relevant Stmts (app)
poly-call finishes, elapsed time: 0.10s
Tai-e finishes, elapsed time: 205.03s
```

</details>
