### PR TITLE
Move the addition of reflection log classes to `Options.postProcess`

### DIFF
--- a/src/main/java/pascal/taie/Main.java
+++ b/src/main/java/pascal/taie/Main.java
@@ -58,7 +58,7 @@ public class Main {
                 logger.info("No analyses are specified");
                 System.exit(0);
             }
-            buildWorld(options, plan.analyses());
+            buildWorld(options);
             executePlan(plan);
         }, "Tai-e");
         LoggerConfigs.reconfigure();
@@ -117,12 +117,11 @@ public class Main {
     public static void buildWorld(String... args) {
         Options options = Options.parse(args);
         LoggerConfigs.setOutput(options.getOutputDir());
-        Plan plan = processConfigs(options);
-        buildWorld(options, plan.analyses());
+        buildWorld(options);
         LoggerConfigs.reconfigure();
     }
 
-    private static void buildWorld(Options options, List<AnalysisConfig> analyses) {
+    private static void buildWorld(Options options) {
         Monitor.runAndCount(() -> {
             try {
                 Class<? extends WorldBuilder> builderClass = options.getWorldBuilderClass();
@@ -131,7 +130,7 @@ public class Main {
                 if (options.isWorldCacheMode()) {
                     builder = new CachedWorldBuilder(builder);
                 }
-                builder.build(options, analyses);
+                builder.build(options);
                 logger.info("{} classes with {} methods in the world",
                         World.get()
                                 .getClassHierarchy()
@@ -143,7 +142,7 @@ public class Main {
                                 .mapToInt(c -> c.getDeclaredMethods().size())
                                 .sum());
             } catch (InstantiationException | IllegalAccessException |
-                    NoSuchMethodException | InvocationTargetException e) {
+                     NoSuchMethodException | InvocationTargetException e) {
                 System.err.println("Failed to build world due to " + e);
                 System.exit(1);
             }

--- a/src/main/java/pascal/taie/WorldBuilder.java
+++ b/src/main/java/pascal/taie/WorldBuilder.java
@@ -22,10 +22,7 @@
 
 package pascal.taie;
 
-import pascal.taie.config.AnalysisConfig;
 import pascal.taie.config.Options;
-
-import java.util.List;
 
 /**
  * Interface for {@link World} builder.
@@ -35,10 +32,8 @@ public interface WorldBuilder {
     /**
      * Builds a new instance of {@link World} and make it globally accessible
      * through static methods of {@link World}.
-     * TODO: remove {@code analyses}.
      *
-     * @param options  the options
-     * @param analyses the analyses to be executed
+     * @param options the options
      */
-    void build(Options options, List<AnalysisConfig> analyses);
+    void build(Options options);
 }


### PR DESCRIPTION
This PR address the need for adding classes from the reflection log to the closed-world for different frontends in a uniform way, by making 3 following changes:
1. The type of `Options.analyses` is changed from `Map<String, String>` to `Map<String, AnalysisOptions>`. This is because accessing reflection logs requires `AnalysisOptions`, but they are not accessible until the processing of `Options` is done. Moving the parsing logic of `AnalysisOptions` from `PlanConfig` to `Options` via picocli converters simplifies `PlanConfig` while making `Options` cohesive.
2. The logic of adding classes in the reflection log is moved from `SootWorldBuilder` to `Options.postProcess`. This leaves world builders now unaware of reflection and analyses.
3. `WorldBuilder.build` does not need its `analyses` argument anymore, since `AnalysisOptions` can be now accessed via `Options`. This simplifies the interface of all world builders.